### PR TITLE
Add FOSSA workflow to enable license scanning

### DIFF
--- a/.github/workflows/fossa-license-scan.yml
+++ b/.github/workflows/fossa-license-scan.yml
@@ -1,0 +1,24 @@
+# More information on this workflow can be found here: https://stackoverflow.com/c/intercom/questions/1270
+
+name: FOSSA License Scan
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  fossa:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Attempt build
+        uses: intercom/attempt-build-action@main
+        continue-on-error: true
+      - name: Run FOSSA
+        uses: intercom/fossa-action@main
+        with:
+          fossa-api-key: ${{ secrets.FOSSA_API_KEY }}
+          fossa-event-receiver-token: ${{ secrets.FOSSA_EVENT_RECEIVER_TOKEN }}
+          datadog-api-key: ${{ secrets.DATADOG_API_KEY }}


### PR DESCRIPTION
FOSSA is a tool for scanning a repository to ensure that its dependencies are properly licensed. License scanning is a requirement from Legal and needs to be run in all of the repositories that we use.

This is an automatic PR which adds a new GitHub Actions workflow (in `.github/workflows/fossa-license-scan.yml`) that will run FOSSA on every push to the `main`/`master` branch using [`fossa-cli`](https://github.com/fossas/fossa-cli).

This PR is being batch added to all of our existing repos which should be running FOSSA scans and the PR will be approved automatically. This will run parallelly in GitHub Actions whenever there is a push to the `main`/`master` branch and will not block deployments. If the FOSSA action detects any licensing issues it will open an issue in GitHub to team-cloud retrospectively.

For more information on the `fossa-license-scan.yml` workflow, see: https://stackoverflow.com/c/intercom/questions/1270